### PR TITLE
In Memory File Zipping

### DIFF
--- a/Helpers/AesManager.cs
+++ b/Helpers/AesManager.cs
@@ -51,6 +51,40 @@ namespace WindowsFormsApplication1
         /// <param name="outputFilePath">Full path of the encrypted file</param>
         /// <param name="key">AES encryption key</param>
         /// <param name="iv">AES initialization vector</param>
+        public static byte[] EncryptFile(byte[] fileContent, byte[] key, byte[] iv)
+        {
+            using (AesCryptoServiceProvider aes = new AesCryptoServiceProvider())
+            {
+                aes.Mode = CipherMode.ECB;
+                aes.Key = key;
+                aes.IV = iv;
+
+
+                using (ICryptoTransform cryptoTransform = aes.CreateEncryptor(aes.Key, aes.IV))
+                {
+                    using (MemoryStream plain = new MemoryStream(fileContent))
+                    {
+                        using (MemoryStream encrypted = new MemoryStream())
+                        {
+                            using (CryptoStream cs = new CryptoStream(encrypted, cryptoTransform, CryptoStreamMode.Write))
+                            {
+                                plain.CopyTo(cs, bufferSize);
+                            }
+
+                            return encrypted.ToArray();
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Encrypts a file with AES
+        /// </summary>
+        /// <param name="filePath">Full path of the file to be encrypted</param>
+        /// <param name="outputFilePath">Full path of the encrypted file</param>
+        /// <param name="key">AES encryption key</param>
+        /// <param name="iv">AES initialization vector</param>
         public static void EncryptFile(string filePath, string outputFilePath, byte[] key, byte[] iv)
         {
             using (AesCryptoServiceProvider aes = new AesCryptoServiceProvider())
@@ -114,14 +148,13 @@ namespace WindowsFormsApplication1
         /// <param name="encryptionCert">The certificate used for encryption</param>
         /// <param name="encryptionCertPassword">The password for the encryption certificate</param>
         /// <param name="outputFilePath">Full path of the encrypted file</param>
-        public static void EncryptAesKey(byte[] payload, string encryptionCert, string encryptionCertPassword, string outputFilePath)
+        public static byte[] EncryptAesKey(byte[] payload, string encryptionCert, string encryptionCertPassword)
         {
             X509Certificate2 cert = new X509Certificate2(encryptionCert, encryptionCertPassword);
 
             using (RSACryptoServiceProvider rsa = cert.PublicKey.Key as RSACryptoServiceProvider)
             {
-                byte[] encryptedKey = rsa.Encrypt(payload, false);
-                File.WriteAllBytes(outputFilePath, encryptedKey);
+                return rsa.Encrypt(payload, false);
             }
         }
 

--- a/Helpers/ExtensionMethods.cs
+++ b/Helpers/ExtensionMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using System.Windows.Forms;
 
 namespace WindowsFormsApplication1
@@ -32,7 +33,17 @@ namespace WindowsFormsApplication1
             MessageBox.Show(errorMessage, messageBoxTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
         }
 
+        public static byte[] GetBytes(this string str)
+        {
+            byte[] bytes = new byte[str.Length * sizeof(char)];
+            System.Buffer.BlockCopy(str.ToCharArray(), 0, bytes, 0, bytes.Length);
+            return bytes;
+        }
 
+        public static byte[] GetUTF8Bytes(this string str)
+        {
+            return Encoding.UTF8.GetBytes(str);
+        }
 
     }
 }

--- a/Helpers/XmlManager.cs
+++ b/Helpers/XmlManager.cs
@@ -314,5 +314,60 @@ namespace WindowsFormsApplication1
                 return signed.CheckSignature();
             }
         }
+
+        public static XmlDocument GenerateMetadata(string senderGIIN, string senderFile, string fileCreationDateTime, int taxYear)
+        {
+            XmlDocument document = new XmlDocument();
+
+            using (MemoryStream xmlContent = new MemoryStream())
+            {
+
+                XmlWriterSettings settings = new XmlWriterSettings();
+                settings.Indent = true;
+                settings.IndentChars = ("\t");
+                //settings.OmitXmlDeclaration = false;
+                settings.NewLineHandling = NewLineHandling.Replace;
+                //settings.CloseOutput = true;
+                settings.ConformanceLevel = ConformanceLevel.Document;
+                settings.Encoding = new UTF8Encoding(false);
+
+
+
+                XmlWriter writer = XmlWriter.Create(xmlContent, settings);
+                writer.WriteStartDocument();
+
+                writer.WriteStartElement("FATCAIDESSenderFileMetadata", "urn:fatca:idessenderfilemetadata");
+                writer.WriteAttributeString("xmlns", "xsi", null, "http://www.w3.org/2001/XMLSchema-instance");
+                writer.WriteStartElement("FATCAEntitySenderId");
+                writer.WriteString(senderGIIN);
+                writer.WriteEndElement();
+                writer.WriteStartElement("FATCAEntityReceiverId");
+                writer.WriteString("000000.00000.TA.840");
+                writer.WriteEndElement();
+                writer.WriteStartElement("FATCAEntCommunicationTypeCd");
+                writer.WriteString("RPT");
+                writer.WriteEndElement();
+                writer.WriteStartElement("SenderFileId");
+                writer.WriteString(senderFile);
+                writer.WriteEndElement();
+                writer.WriteStartElement("FileCreateTs");
+                writer.WriteString(fileCreationDateTime);
+                writer.WriteEndElement();
+                writer.WriteStartElement("TaxYear");
+                writer.WriteString(taxYear.ToString());
+                writer.WriteEndElement();
+                writer.WriteStartElement("FileRevisionInd");
+                writer.WriteString("false");
+                writer.WriteEndElement();
+
+                writer.WriteEndDocument();
+                writer.Flush();
+                writer.Close();
+
+
+                document.LoadXml(Encoding.UTF8.GetString(xmlContent.ToArray()));
+            }
+            return document;
+        }
     }
 }

--- a/Helpers/ZipManager.cs
+++ b/Helpers/ZipManager.cs
@@ -1,10 +1,57 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.IO.Compression;
 
 namespace WindowsFormsApplication1
 {
     class ZipManager
     {
+        /// <summary>
+        /// Creates a Zip file in Memory
+        /// </summary>
+        /// <param name="fileName">Name of the file to be zipped</param>
+        /// <param name="file">Content of the file</param>
+        /// <returns>Byte Array with the Zip file</returns>
+        public static byte[] ZipContent(string fileName, byte[] file)
+        {
+            Dictionary<string, byte[]> files = new Dictionary<string, byte[]>();
+            files.Add(fileName, file);
+            return ZipContent(files);
+        }
+
+        /// <summary>
+        /// Creates a Zip file in Memory from a list of files
+        /// </summary>
+        /// <param name="files">Dictionary with the file names and file content</param>
+        /// <returns>Byte Array with the Zip file (including all files)</returns>
+        public static byte[] ZipContent(Dictionary<string, byte[]> files)
+        {
+            using (MemoryStream memStream = new MemoryStream())
+            {
+                // create a new zip archiv in the memory stream
+                using (ZipArchive memZipFile = new ZipArchive(memStream, ZipArchiveMode.Create, true))
+                {
+                    foreach (var entry in files)
+                    {
+                        // create a new entry in the zip file
+                        var tmpFile = memZipFile.CreateEntry(entry.Key);
+                        // write the content to the new file
+                        using (Stream fileContent = tmpFile.Open())
+                        {
+                            using (BinaryWriter writer = new BinaryWriter(fileContent))
+                            {
+                                // write the content of the file
+                                writer.Write(entry.Value);
+                            }
+                        }
+                    }
+                }
+
+                return memStream.ToArray();
+            }
+        }
+
+
         public static void CreateArchive(string inputFileName, string outputFileName)
         {
             using (FileStream fs = new FileStream(outputFileName, FileMode.Create, FileAccess.Write))


### PR DESCRIPTION
Replace the code to zip the files in memory instead of writing them to
the disk first and some minor code adjustment and cleanup.
## 

I was working on this code to submit files through the IDES Gateway, when creating several files or the same file multiples times it becomes bit messy having all these files in the destination folder, generating just the final zip file without the need of creating the "temporary" files first would produce a cleaner result. And the user can always find the files inside the .Zip file in case he wants to take a look to them.

Also moved the Creation of the Metadata XML file to the XMLManager class.
